### PR TITLE
Add Windows support, tag filtering, and fix multibyte char panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -69,15 +69,15 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "bitflags"
-version = "2.8.0"
+name = "cfg-if"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -132,7 +132,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -155,20 +190,30 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.0.2"
+name = "linux-raw-sys"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "bitflags 2.8.0",
- "libc",
- "redox_syscall",
+ "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -177,16 +222,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
+name = "mio"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -208,18 +288,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "regex"
@@ -251,15 +325,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustycat-android"
 version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "crossterm",
  "regex",
  "termion",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -280,14 +411,12 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "2.0.3"
+version = "4.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
+checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
 dependencies = [
  "libc",
- "libredox",
  "numtoa",
- "redox_termios",
 ]
 
 [[package]]
@@ -303,12 +432,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,11 @@ colored = "2.1.0"
 clap = { version = "4.4.18", features = ["derive"] }
 regex = "1.10.3"
 anyhow = "1.0.79"
-termion = "2.0.1"
+
+[target.'cfg(unix)'.dependencies]
+termion = "4"
+
+[target.'cfg(windows)'.dependencies]
+crossterm = "0.28"
+
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ```bash
 rcat "com.example.app.*"
 ```
-  
+
 </div>
 
 
@@ -62,6 +62,14 @@ Filter by log level:
 ```bash
 # Show only Debug and Error logs
 rcat -l "D,E"
+```
+
+Filter by tag:
+```bash
+# Show only logs from specific tag
+rcat --tag SystemUI
+# or
+rcat -g ActivityManager
 ```
 
 Filter by content:

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,10 @@ struct Args {
     /// Filter by tag name (exact match)
     #[arg(short = 'g', long)]
     tag: Option<String>,
+
+    /// Show PID in output
+    #[arg(short = 'p', long, default_value_t = false)]
+    show_pid: bool,
 }
 
 fn get_pids_for_package(pattern: &str) -> Result<Vec<String>> {
@@ -139,7 +143,7 @@ fn get_pids_for_package(pattern: &str) -> Result<Vec<String>> {
     Ok(pids)
 }
 
-fn extract_log_parts(line: &str) -> Option<(String, String, String, String)> {
+fn extract_log_parts(line: &str) -> Option<(String, String, String, String, String)> {
     let parts: Vec<&str> = line.split_whitespace().collect();
     if parts.len() < 6 {
         return None;
@@ -163,8 +167,11 @@ fn extract_log_parts(line: &str) -> Option<(String, String, String, String)> {
         (tag_and_message.as_str(), "")
     };
 
+    let pid = parts[2].to_string();
+
     Some((
         timestamp,
+        pid,
         tag.trim().to_string(),
         level.to_string(),
         message.trim_start_matches(": ").to_string()
@@ -242,8 +249,8 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
     result
 }
 
-fn format_log_line(line: &str, hide_timestamp: bool, tag_filter: &Option<String>) -> Option<String> {
-    if let Some((timestamp, tag, level, content)) = extract_log_parts(line) {
+fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter: &Option<String>) -> Option<String> {
+    if let Some((timestamp, pid, tag, level, content)) = extract_log_parts(line) {
         // Apply tag filter if specified
         if let Some(filter_tag) = tag_filter {
             if &tag != filter_tag {
@@ -276,9 +283,16 @@ fn format_log_line(line: &str, hide_timestamp: bool, tag_filter: &Option<String>
             format!("{:<width$} ", timestamp.bright_black(), width = TIMESTAMP_WIDTH)
         };
 
-        Some(format!("{}{}{} {} {}",
+        let pid_part = if show_pid {
+            format!("{} ", pid.bright_black())
+        } else {
+            "".to_string()
+        };
+
+        Some(format!("{}{}{}{} {} {}",
             padding,
             timestamp_part,
+            pid_part,
             tag_display,
             level_str,
             formatted_content
@@ -289,7 +303,7 @@ fn format_log_line(line: &str, hide_timestamp: bool, tag_filter: &Option<String>
 }
 
 fn should_display_log(line: &str, args: &Args) -> bool {
-    if let Some((_, tag, level, content)) = extract_log_parts(line) {
+    if let Some((_, _, tag, level, content)) = extract_log_parts(line) {
         // Check tag filter
         if let Some(tag_filter) = &args.tag {
             if &tag != tag_filter {
@@ -339,7 +353,7 @@ fn main() -> Result<()> {
         .output()
         .context("Failed to clear logcat buffer")?;
 
-    if let Some(package_pattern) = args.package_pattern.as_ref() {
+    let pid_filter: Vec<String> = if let Some(package_pattern) = args.package_pattern.as_ref() {
         let pids = get_pids_for_package(package_pattern)?;
 
         if pids.is_empty() {
@@ -347,11 +361,11 @@ fn main() -> Result<()> {
             return Ok(());
         }
 
-        // Add --pid argument for each found PID
-        for pid in pids {
-            logcat_cmd.arg("--pid").arg(pid);
-        }
-    }
+        println!("Monitoring PIDs: {}", pids.join(", "));
+        pids
+    } else {
+        Vec::new()
+    };
 
     let process = logcat_cmd
         .stdout(Stdio::piped())
@@ -362,8 +376,15 @@ fn main() -> Result<()> {
 
     for line in reader.lines() {
         if let Ok(line) = line {
+            // Filter by PID in Rust (adb logcat supports only one --pid)
+            if !pid_filter.is_empty() {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() < 3 || !pid_filter.iter().any(|p| p == parts[2]) {
+                    continue;
+                }
+            }
             if should_display_log(&line, &args) {
-                if let Some(formatted) = format_log_line(&line, args.no_timestamp, &args.tag) {
+                if let Some(formatted) = format_log_line(&line, args.no_timestamp, args.show_pid, &args.tag) {
                     println!("{}", formatted);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,14 +207,19 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
         let mut remaining = line;
 
         while !remaining.is_empty() {
-            let (chunk, rest) = if remaining.len() > available_width {
-                // Try to break at the last space within the available width
-                let slice = &remaining[..available_width];
+            let (chunk, rest) = if remaining.chars().count() > available_width {
+                // Find the byte index at which `available_width` chars end
+                let cut = remaining
+                    .char_indices()
+                    .nth(available_width)
+                    .map(|(i, _)| i)
+                    .unwrap_or(remaining.len());
+                let slice = &remaining[..cut];
+                // Try to break at the last space within the slice
                 if let Some(last_space) = slice.rfind(' ') {
                     remaining.split_at(last_space)
                 } else {
-                    // If no space found, break at available width
-                    remaining.split_at(available_width)
+                    remaining.split_at(cut)
                 }
             } else {
                 (remaining, "")

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,10 @@ use std::io::{BufRead, BufReader};
 use std::process;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use termion::event::Key;
+#[cfg(unix)]
 use termion::input::TermRead;
-use termion::terminal_size;
+#[cfg(unix)]
+use termion::event::Key;
 
 const TAG_WIDTH: usize = 25;
 const LEFT_PADDING: usize = 2;
@@ -35,6 +36,45 @@ const TAG_COLORS_LIST: &[Color] = &[
     Color::BrightMagenta,
     Color::BrightCyan,
 ];
+
+#[cfg(unix)]
+fn get_terminal_width() -> usize {
+    termion::terminal_size().map(|(w, _)| w as usize).unwrap_or(80)
+}
+
+#[cfg(windows)]
+fn get_terminal_width() -> usize {
+    crossterm::terminal::size().map(|(w, _)| w as usize).unwrap_or(80)
+}
+
+#[cfg(unix)]
+fn spawn_input_handler() {
+    std::thread::spawn(|| {
+        let stdin = std::io::stdin();
+        for key in stdin.keys() {
+            if let Ok(Key::Char('q')) | Ok(Key::Char('Q')) = key {
+                process::exit(0);
+            }
+        }
+    });
+}
+
+#[cfg(windows)]
+fn spawn_input_handler() {
+    std::thread::spawn(|| {
+        use crossterm::event::{self, Event, KeyCode};
+        loop {
+            if let Ok(Event::Key(key_event)) = event::read() {
+                match key_event.code {
+                    KeyCode::Char('q') | KeyCode::Char('Q') => {
+                        process::exit(0);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+}
 
 fn get_tag_color(tag: &str) -> Color {
     TAG_COLORS.with(|colors| {
@@ -104,13 +144,13 @@ fn extract_log_parts(line: &str) -> Option<(String, String, String, String)> {
     // Standard logcat format:
     // Date Time PID TID Level Tag: Message
     // 02-03 15:44:41.704 2359 3654 I Tag: Message
-    
+
     // Extract time with milliseconds (15:44:41.704)
     let time_parts: Vec<&str> = parts[1].split('.').collect();
     let time = time_parts[0];
     let ms = time_parts.get(1).unwrap_or(&"000");
     let timestamp = format!("{}.{}", time, &ms[..3]); // Ensure we only take 3 digits for milliseconds
-    
+
     let level = parts[4];
     let tag_and_message = parts[5..].join(" ");
     let (tag, message) = if let Some(pos) = tag_and_message.find(": ") {
@@ -150,10 +190,10 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
     let timestamp_width = if hide_timestamp { 0 } else { TIMESTAMP_WIDTH };
     let message_start_padding = LEFT_PADDING + timestamp_width + TAG_WIDTH + 4 + 2; // +4 for level, +2 for spaces
     let padding = " ".repeat(message_start_padding);
-    
+
     // Get terminal width
-    let term_width = terminal_size().map(|(w, _)| w as usize).unwrap_or(80);
-    
+    let term_width = get_terminal_width();
+
     let mut result = String::new();
     let mut is_first_line = true;
 
@@ -161,11 +201,11 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
         if !is_first_line {
             result.push_str(&format!("\n{}", padding));
         }
-        
+
         // Available width for the message content
         let available_width = term_width.saturating_sub(message_start_padding);
         let mut remaining = line;
-        
+
         while !remaining.is_empty() {
             let (chunk, rest) = if remaining.len() > available_width {
                 // Try to break at the last space within the available width
@@ -179,17 +219,17 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
             } else {
                 (remaining, "")
             };
-            
+
             if !is_first_line || !result.is_empty() {
                 result.push_str(&format!("\n{}", padding));
             }
             result.push_str(&chunk.color(color).to_string());
             remaining = rest.trim_start();
         }
-        
+
         is_first_line = false;
     }
-    
+
     result
 }
 
@@ -198,7 +238,7 @@ fn format_log_line(line: &str, hide_timestamp: bool) -> Option<String> {
         let (level_str, color) = get_level_color(&level);
         let padding = " ".repeat(LEFT_PADDING);
         let formatted_content = format_multiline_content(&content, color, hide_timestamp);
-        
+
         // Check if tag has changed
         let show_tag = LAST_TAG.with(|last_tag| {
             let mut last = last_tag.borrow_mut();
@@ -213,14 +253,14 @@ fn format_log_line(line: &str, hide_timestamp: bool) -> Option<String> {
         } else {
             format!("{:>width$}", " ".repeat(tag.len()).color(tag_color), width = TAG_WIDTH)
         };
-        
+
         let timestamp_part = if hide_timestamp {
             "".to_string()
         } else {
             format!("{:<width$} ", timestamp.bright_black(), width = TIMESTAMP_WIDTH)
         };
-        
-        Some(format!("{}{}{} {} {}", 
+
+        Some(format!("{}{}{} {} {}",
             padding,
             timestamp_part,
             tag_display,
@@ -265,16 +305,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // Set up input handling in a separate thread
-    std::thread::spawn(|| {
-        let stdin = std::io::stdin();
-        for key in stdin.keys() {
-            if let Ok(key) = key {
-                if matches!(key, Key::Char('q') | Key::Char('Q')) {
-                    process::exit(0);
-                }
-            }
-        }
-    });
+    spawn_input_handler();
 
     let mut logcat_cmd = Command::new("adb");
     logcat_cmd.args(["logcat", "-v", "threadtime"]);
@@ -287,7 +318,7 @@ fn main() -> Result<()> {
 
     if let Some(package_pattern) = args.package_pattern.as_ref() {
         let pids = get_pids_for_package(package_pattern)?;
-        
+
         if pids.is_empty() {
             println!("No matching processes found for pattern: {}", package_pattern);
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,10 @@ struct Args {
     /// Exclude logs containing this text (case-insensitive)
     #[arg(short = 'e', long)]
     exclude: Option<String>,
+
+    /// Filter by tag name (exact match)
+    #[arg(short = 'g', long)]
+    tag: Option<String>,
 }
 
 fn get_pids_for_package(pattern: &str) -> Result<Vec<String>> {
@@ -238,8 +242,15 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
     result
 }
 
-fn format_log_line(line: &str, hide_timestamp: bool) -> Option<String> {
+fn format_log_line(line: &str, hide_timestamp: bool, tag_filter: &Option<String>) -> Option<String> {
     if let Some((timestamp, tag, level, content)) = extract_log_parts(line) {
+        // Apply tag filter if specified
+        if let Some(filter_tag) = tag_filter {
+            if &tag != filter_tag {
+                return None;
+            }
+        }
+
         let (level_str, color) = get_level_color(&level);
         let padding = " ".repeat(LEFT_PADDING);
         let formatted_content = format_multiline_content(&content, color, hide_timestamp);
@@ -278,7 +289,14 @@ fn format_log_line(line: &str, hide_timestamp: bool) -> Option<String> {
 }
 
 fn should_display_log(line: &str, args: &Args) -> bool {
-    if let Some((_, _, level, content)) = extract_log_parts(line) {
+    if let Some((_, tag, level, content)) = extract_log_parts(line) {
+        // Check tag filter
+        if let Some(tag_filter) = &args.tag {
+            if &tag != tag_filter {
+                return false;
+            }
+        }
+
         // Check log level filter
         if let Some(level_filter) = &args.level {
             if !level_filter.split(',').any(|l| l.trim() == level) {
@@ -345,7 +363,7 @@ fn main() -> Result<()> {
     for line in reader.lines() {
         if let Ok(line) = line {
             if should_display_log(&line, &args) {
-                if let Some(formatted) = format_log_line(&line, args.no_timestamp) {
+                if let Some(formatted) = format_log_line(&line, args.no_timestamp, &args.tag) {
                     println!("{}", formatted);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,21 +99,21 @@ struct Args {
     #[arg(short = 't', long, default_value_t = false)]
     no_timestamp: bool,
 
-    /// Filter by log level (e.g., D,I,W,E,V,F)
-    #[arg(short = 'l', long)]
-    level: Option<String>,
+    /// Filter by log level (e.g., D,I,W,E,V,F) — repeatable: -l D -l I
+    #[arg(short = 'l', long, action = clap::ArgAction::Append)]
+    level: Vec<String>,
 
-    /// Filter logs containing this text (case-insensitive)
-    #[arg(short = 'f', long)]
-    filter: Option<String>,
+    /// Filter logs containing this text (case-insensitive) — repeatable: AND logic
+    #[arg(short = 'f', long, action = clap::ArgAction::Append)]
+    filter: Vec<String>,
 
-    /// Exclude logs containing this text (case-insensitive)
-    #[arg(short = 'e', long)]
-    exclude: Option<String>,
+    /// Exclude logs containing this text (case-insensitive) — repeatable: OR logic
+    #[arg(short = 'e', long, action = clap::ArgAction::Append)]
+    exclude: Vec<String>,
 
-    /// Filter by tag name (exact match)
-    #[arg(short = 'g', long)]
-    tag: Option<String>,
+    /// Filter by tag name (exact match) — repeatable: OR logic
+    #[arg(short = 'g', long, action = clap::ArgAction::Append)]
+    tag: Vec<String>,
 
     /// Show PID in output
     #[arg(short = 'p', long, default_value_t = false)]
@@ -249,13 +249,10 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
     result
 }
 
-fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter: &Option<String>) -> Option<String> {
+fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter: &[String]) -> Option<String> {
     if let Some((timestamp, pid, tag, level, content)) = extract_log_parts(line) {
-        // Apply tag filter if specified
-        if let Some(filter_tag) = tag_filter {
-            if &tag != filter_tag {
-                return None;
-            }
+        if !tag_filter.is_empty() && !tag_filter.iter().any(|t| t == &tag) {
+            return None;
         }
 
         let (level_str, color) = get_level_color(&level);
@@ -304,30 +301,26 @@ fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter:
 
 fn should_display_log(line: &str, args: &Args) -> bool {
     if let Some((_, _, tag, level, content)) = extract_log_parts(line) {
-        // Check tag filter
-        if let Some(tag_filter) = &args.tag {
-            if &tag != tag_filter {
+        // Check tag filter (OR)
+        if !args.tag.is_empty() && !args.tag.iter().any(|t| t == &tag) {
+            return false;
+        }
+
+        // Check log level filter (OR, comma-separated values also supported)
+        if !args.level.is_empty() && !args.level.iter().any(|l| l.split(',').any(|s| s.trim() == level)) {
+            return false;
+        }
+
+        // Check content filter (AND: all must match)
+        for f in &args.filter {
+            if !content.to_lowercase().contains(&f.to_lowercase()) {
                 return false;
             }
         }
 
-        // Check log level filter
-        if let Some(level_filter) = &args.level {
-            if !level_filter.split(',').any(|l| l.trim() == level) {
-                return false;
-            }
-        }
-
-        // Check content filter
-        if let Some(filter) = &args.filter {
-            if !content.to_lowercase().contains(&filter.to_lowercase()) {
-                return false;
-            }
-        }
-
-        // Check content exclusion
-        if let Some(exclude) = &args.exclude {
-            if content.to_lowercase().contains(&exclude.to_lowercase()) {
+        // Check content exclusion (OR: any match excludes)
+        for e in &args.exclude {
+            if content.to_lowercase().contains(&e.to_lowercase()) {
                 return false;
             }
         }
@@ -384,7 +377,7 @@ fn main() -> Result<()> {
                 }
             }
             if should_display_log(&line, &args) {
-                if let Some(formatted) = format_log_line(&line, args.no_timestamp, args.show_pid, &args.tag) {
+                if let Some(formatted) = format_log_line(&line, args.no_timestamp, args.show_pid, &args.tag[..]) {
                     println!("{}", formatted);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::*;
+use regex::Regex;
 use std::process::{Command, Stdio};
 use std::io::{BufRead, BufReader};
 use std::process;
@@ -92,7 +93,7 @@ fn get_tag_color(tag: &str) -> Color {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Class name pattern to filter by tag (e.g., com.example.app or com.example.*)
+    /// Class name regex to filter by process name (e.g., com.example.app, com.example.*, or .*)
     class_pattern: Option<String>,
 
     /// Disable timestamp display in the output
@@ -132,6 +133,25 @@ fn get_connected_devices() -> Vec<String> {
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 2 && parts[1] == "device" {
                 Some(parts[0].to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn get_matching_pids(device: &str, regex: &Regex) -> Vec<String> {
+    let output = match Command::new("adb").args(["-s", device, "shell", "ps", "-A"]).output() {
+        Ok(o) => o,
+        Err(_) => return vec![],
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .skip(1) // skip the header row (USER PID ... NAME)
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 && regex.is_match(parts[parts.len() - 1]) {
+                Some(parts[1].to_string())
             } else {
                 None
             }
@@ -365,22 +385,15 @@ fn main() -> Result<()> {
         .output()
         .context("Failed to clear logcat buffer")?;
 
-    let pids: Option<Arc<Mutex<Vec<String>>>> = if let Some(package) = args.class_pattern.clone() {
+    let pids: Option<Arc<Mutex<Vec<String>>>> = if let Some(pattern) = args.class_pattern.clone() {
+        let regex = Regex::new(&pattern).context("Invalid class pattern")?;
         let pids = Arc::new(Mutex::new(Vec::<String>::new()));
         let pids_clone = pids.clone();
         let device_clone = device.clone();
         std::thread::spawn(move || {
             loop {
-                let output = Command::new("adb")
-                    .args(["-s", &device_clone, "shell", "pidof", &package])
-                    .output();
-                if let Ok(output) = output {
-                    let new_pids: Vec<String> = String::from_utf8_lossy(&output.stdout)
-                        .split_whitespace()
-                        .map(|s| s.to_string())
-                        .collect();
-                    *pids_clone.lock().unwrap() = new_pids;
-                }
+                let new_pids = get_matching_pids(&device_clone, &regex);
+                *pids_clone.lock().unwrap() = new_pids;
                 std::thread::sleep(std::time::Duration::from_secs(2));
             }
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::*;
-use regex::Regex;
 use std::process::{Command, Stdio};
 use std::io::{BufRead, BufReader};
 use std::process;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 #[cfg(unix)]
 use termion::input::TermRead;
 #[cfg(unix)]
@@ -92,7 +92,7 @@ fn get_tag_color(tag: &str) -> Color {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Class name pattern to filter by process name (e.g., com.example.app or com.example.*)
+    /// Class name pattern to filter by tag (e.g., com.example.app or com.example.*)
     class_pattern: Option<String>,
 
     /// Disable timestamp display in the output
@@ -114,10 +114,6 @@ struct Args {
     /// Filter by tag name (exact match) — repeatable: OR logic
     #[arg(short = 'g', long, action = clap::ArgAction::Append)]
     tag: Vec<String>,
-
-    /// Show PID in output
-    #[arg(short = 'p', long, default_value_t = false)]
-    show_pid: bool,
 
     /// Target device serial number (use when multiple devices are connected)
     #[arg(short = 'd', long)]
@@ -143,25 +139,7 @@ fn get_connected_devices() -> Vec<String> {
         .collect()
 }
 
-fn build_pid_class_map(device: &str) -> HashMap<String, String> {
-    let output = match Command::new("adb").args(["-s", device, "shell", "ps", "-A"]).output() {
-        Ok(o) => o,
-        Err(_) => return HashMap::new(),
-    };
-    let mut map = HashMap::new();
-    let processes = String::from_utf8_lossy(&output.stdout);
-    for line in processes.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() >= 2 {
-            let pid = parts[1].to_string();
-            let class_name = parts[parts.len() - 1].to_string();
-            map.insert(pid, class_name);
-        }
-    }
-    map
-}
-
-fn extract_log_parts(line: &str) -> Option<(String, String, String, String, String)> {
+fn extract_log_parts(line: &str) -> Option<(String, String, String, String)> {
     let parts: Vec<&str> = line.split_whitespace().collect();
     if parts.len() < 6 {
         return None;
@@ -185,11 +163,8 @@ fn extract_log_parts(line: &str) -> Option<(String, String, String, String, Stri
         (tag_and_message.as_str(), "")
     };
 
-    let pid = parts[2].to_string();
-
     Some((
         timestamp,
-        pid,
         tag.trim().to_string(),
         level.to_string(),
         message.trim_start_matches(": ").to_string()
@@ -267,8 +242,8 @@ fn format_multiline_content(content: &str, color: Color, hide_timestamp: bool) -
     result
 }
 
-fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter: &[String]) -> Option<String> {
-    if let Some((timestamp, pid, tag, level, content)) = extract_log_parts(line) {
+fn format_log_line(line: &str, hide_timestamp: bool, tag_filter: &[String]) -> Option<String> {
+    if let Some((timestamp, tag, level, content)) = extract_log_parts(line) {
         if !tag_filter.is_empty() && !tag_filter.iter().any(|t| t == &tag) {
             return None;
         }
@@ -277,7 +252,6 @@ fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter:
         let padding = " ".repeat(LEFT_PADDING);
         let formatted_content = format_multiline_content(&content, color, hide_timestamp);
 
-        // Check if tag has changed
         let show_tag = LAST_TAG.with(|last_tag| {
             let mut last = last_tag.borrow_mut();
             let changed = *last != tag;
@@ -298,16 +272,9 @@ fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter:
             format!("{:<width$} ", timestamp.bright_black(), width = TIMESTAMP_WIDTH)
         };
 
-        let pid_part = if show_pid {
-            format!("{} ", pid.bright_black())
-        } else {
-            "".to_string()
-        };
-
-        Some(format!("{}{}{}{} {} {}",
+        Some(format!("{}{}{} {} {}",
             padding,
             timestamp_part,
-            pid_part,
             tag_display,
             level_str,
             formatted_content
@@ -317,8 +284,22 @@ fn format_log_line(line: &str, hide_timestamp: bool, show_pid: bool, tag_filter:
     }
 }
 
-fn should_display_log(line: &str, args: &Args) -> bool {
-    if let Some((_, _, tag, level, content)) = extract_log_parts(line) {
+fn should_display_log(line: &str, args: &Args, pids: Option<&Arc<Mutex<Vec<String>>>>) -> bool {
+    if let Some((_, tag, level, content)) = extract_log_parts(line) {
+        // Check PID filter
+        if let Some(pids) = pids {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 3 {
+                let line_pid = parts[2];
+                let pids = pids.lock().unwrap();
+                if !pids.iter().any(|p| p == line_pid) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
         // Check tag filter (OR)
         if !args.tag.is_empty() && !args.tag.iter().any(|t| t == &tag) {
             return false;
@@ -384,21 +365,29 @@ fn main() -> Result<()> {
         .output()
         .context("Failed to clear logcat buffer")?;
 
-    let (class_regex, pid_class_map): (Option<Regex>, HashMap<String, String>) =
-        if let Some(pattern) = args.class_pattern.as_ref() {
-            let regex_pattern = pattern.replace(".", "\\.").replace("*", ".*");
-            let regex = Regex::new(&regex_pattern).context("Invalid class pattern")?;
-            let map = loop {
-                let map = build_pid_class_map(&device);
-                if map.values().any(|c| regex.is_match(c)) {
-                    break map;
+    let pids: Option<Arc<Mutex<Vec<String>>>> = if let Some(package) = args.class_pattern.clone() {
+        let pids = Arc::new(Mutex::new(Vec::<String>::new()));
+        let pids_clone = pids.clone();
+        let device_clone = device.clone();
+        std::thread::spawn(move || {
+            loop {
+                let output = Command::new("adb")
+                    .args(["-s", &device_clone, "shell", "pidof", &package])
+                    .output();
+                if let Ok(output) = output {
+                    let new_pids: Vec<String> = String::from_utf8_lossy(&output.stdout)
+                        .split_whitespace()
+                        .map(|s| s.to_string())
+                        .collect();
+                    *pids_clone.lock().unwrap() = new_pids;
                 }
-                std::thread::sleep(std::time::Duration::from_secs(1));
-            };
-            (Some(regex), map)
-        } else {
-            (None, HashMap::new())
-        };
+                std::thread::sleep(std::time::Duration::from_secs(2));
+            }
+        });
+        Some(pids)
+    } else {
+        None
+    };
 
     let process = logcat_cmd
         .stdout(Stdio::piped())
@@ -409,20 +398,8 @@ fn main() -> Result<()> {
 
     for line in reader.lines() {
         if let Ok(line) = line {
-            if let Some(regex) = &class_regex {
-                if !line.starts_with("--------- beginning of") {
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if parts.len() < 3 {
-                        continue;
-                    }
-                    match pid_class_map.get(parts[2]) {
-                        Some(class_name) if regex.is_match(class_name) => {}
-                        _ => continue,
-                    }
-                }
-            }
-            if should_display_log(&line, &args) {
-                if let Some(formatted) = format_log_line(&line, args.no_timestamp, args.show_pid, &args.tag[..]) {
+            if should_display_log(&line, &args, pids.as_ref()) {
+                if let Some(formatted) = format_log_line(&line, args.no_timestamp, &args.tag[..]) {
                     println!("{}", formatted);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use termion::event::Key;
 const TAG_WIDTH: usize = 25;
 const LEFT_PADDING: usize = 2;
 const TIMESTAMP_WIDTH: usize = 12;  // Changed to fit "HH:MM:SS.mmm"
-const TOTAL_PREFIX_WIDTH: usize = LEFT_PADDING + TIMESTAMP_WIDTH + TAG_WIDTH + 3; // +3 for level and spaces
+// const TOTAL_PREFIX_WIDTH: usize = LEFT_PADDING + TIMESTAMP_WIDTH + TAG_WIDTH + 3; // +3 for level and spaces
 
 thread_local! {
     static LAST_TAG: RefCell<String> = RefCell::new(String::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,33 @@ struct Args {
     /// Show PID in output
     #[arg(short = 'p', long, default_value_t = false)]
     show_pid: bool,
+
+    /// Target device serial number (use when multiple devices are connected)
+    #[arg(short = 'd', long)]
+    device: Option<String>,
 }
 
-fn build_pid_class_map() -> HashMap<String, String> {
-    let output = match Command::new("adb").args(["shell", "ps", "-A"]).output() {
+fn get_connected_devices() -> Vec<String> {
+    let output = match Command::new("adb").args(["devices"]).output() {
+        Ok(o) => o,
+        Err(_) => return vec![],
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 && parts[1] == "device" {
+                Some(parts[0].to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn build_pid_class_map(device: &str) -> HashMap<String, String> {
+    let output = match Command::new("adb").args(["-s", device, "shell", "ps", "-A"]).output() {
         Ok(o) => o,
         Err(_) => return HashMap::new(),
     };
@@ -332,12 +355,32 @@ fn main() -> Result<()> {
     // Set up input handling in a separate thread
     spawn_input_handler();
 
+    let device = if let Some(serial) = args.device.as_ref() {
+        serial.clone()
+    } else {
+        let devices = get_connected_devices();
+        match devices.len() {
+            0 => {
+                eprintln!("No devices connected.");
+                return Ok(());
+            }
+            1 => devices.into_iter().next().unwrap(),
+            _ => {
+                eprintln!("Multiple devices connected. Use -d to specify:");
+                for serial in &devices {
+                    eprintln!("  {}", serial);
+                }
+                return Ok(());
+            }
+        }
+    };
+
     let mut logcat_cmd = Command::new("adb");
-    logcat_cmd.args(["logcat", "-v", "threadtime"]);
+    logcat_cmd.args(["-s", &device, "logcat", "-v", "threadtime"]);
 
     // Clear the logcat buffer first
     Command::new("adb")
-        .args(["logcat", "-c"])
+        .args(["-s", &device, "logcat", "-c"])
         .output()
         .context("Failed to clear logcat buffer")?;
 
@@ -346,7 +389,7 @@ fn main() -> Result<()> {
             let regex_pattern = pattern.replace(".", "\\.").replace("*", ".*");
             let regex = Regex::new(&regex_pattern).context("Invalid class pattern")?;
             let map = loop {
-                let map = build_pid_class_map();
+                let map = build_pid_class_map(&device);
                 if map.values().any(|c| regex.is_match(c)) {
                     break map;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,8 @@ fn get_tag_color(tag: &str) -> Color {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Package name pattern to filter (e.g., com.example.app or com.example.*)
-    package_pattern: Option<String>,
+    /// Class name pattern to filter by process name (e.g., com.example.app or com.example.*)
+    class_pattern: Option<String>,
 
     /// Disable timestamp display in the output
     #[arg(short = 't', long, default_value_t = false)]
@@ -120,27 +120,22 @@ struct Args {
     show_pid: bool,
 }
 
-fn get_pids_for_package(pattern: &str) -> Result<Vec<String>> {
-    let regex_pattern = pattern.replace(".", "\\.").replace("*", ".*");
-    let regex = Regex::new(&regex_pattern)?;
-
-    let output = Command::new("adb")
-        .args(["shell", "ps", "-A"])
-        .output()
-        .context("Failed to execute adb shell ps command")?;
-
+fn build_pid_class_map() -> HashMap<String, String> {
+    let output = match Command::new("adb").args(["shell", "ps", "-A"]).output() {
+        Ok(o) => o,
+        Err(_) => return HashMap::new(),
+    };
+    let mut map = HashMap::new();
     let processes = String::from_utf8_lossy(&output.stdout);
-    let mut pids = Vec::new();
-
     for line in processes.lines() {
-        if regex.is_match(line) {
-            if let Some(pid) = line.split_whitespace().nth(1) {
-                pids.push(pid.to_string());
-            }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 {
+            let pid = parts[1].to_string();
+            let class_name = parts[parts.len() - 1].to_string();
+            map.insert(pid, class_name);
         }
     }
-
-    Ok(pids)
+    map
 }
 
 fn extract_log_parts(line: &str) -> Option<(String, String, String, String, String)> {
@@ -346,19 +341,21 @@ fn main() -> Result<()> {
         .output()
         .context("Failed to clear logcat buffer")?;
 
-    let pid_filter: Vec<String> = if let Some(package_pattern) = args.package_pattern.as_ref() {
-        let pids = get_pids_for_package(package_pattern)?;
-
-        if pids.is_empty() {
-            println!("No matching processes found for pattern: {}", package_pattern);
-            return Ok(());
-        }
-
-        println!("Monitoring PIDs: {}", pids.join(", "));
-        pids
-    } else {
-        Vec::new()
-    };
+    let (class_regex, pid_class_map): (Option<Regex>, HashMap<String, String>) =
+        if let Some(pattern) = args.class_pattern.as_ref() {
+            let regex_pattern = pattern.replace(".", "\\.").replace("*", ".*");
+            let regex = Regex::new(&regex_pattern).context("Invalid class pattern")?;
+            let map = loop {
+                let map = build_pid_class_map();
+                if map.values().any(|c| regex.is_match(c)) {
+                    break map;
+                }
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            };
+            (Some(regex), map)
+        } else {
+            (None, HashMap::new())
+        };
 
     let process = logcat_cmd
         .stdout(Stdio::piped())
@@ -369,11 +366,16 @@ fn main() -> Result<()> {
 
     for line in reader.lines() {
         if let Ok(line) = line {
-            // Filter by PID in Rust (adb logcat supports only one --pid)
-            if !pid_filter.is_empty() {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() < 3 || !pid_filter.iter().any(|p| p == parts[2]) {
-                    continue;
+            if let Some(regex) = &class_regex {
+                if !line.starts_with("--------- beginning of") {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() < 3 {
+                        continue;
+                    }
+                    match pid_class_map.get(parts[2]) {
+                        Some(class_name) if regex.is_match(class_name) => {}
+                        _ => continue,
+                    }
                 }
             }
             if should_display_log(&line, &args) {


### PR DESCRIPTION
This pull request introduces improved cross-platform support for terminal handling and adds a new feature for filtering logs by tag. The code now conditionally uses `termion` for Unix and `crossterm` for Windows, ensuring compatibility on both platforms. Additionally, users can filter logs by tag using a new command-line argument, and the documentation has been updated to reflect this feature.

**Cross-platform terminal handling:**

* Updated dependencies in `Cargo.toml` to use `termion` on Unix and `crossterm` on Windows, enabling cross-platform terminal support.
* Refactored terminal width detection and input handling to use the appropriate library (`termion` for Unix, `crossterm` for Windows), including platform-specific implementations of `get_terminal_width` and `spawn_input_handler`. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL10-R13) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR40-R78) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL155-R199) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL268-R331)

**Tag filtering feature:**

* Added a new `--tag`/`-g` argument to filter logs by tag, updated log filtering logic to respect this argument, and modified the log formatting function to apply the tag filter. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR113-R116) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL196-R253) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL236-R299) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL312-R366)
* Updated `README.md` to document the new tag filtering feature with usage examples.

**Unicode and line wrapping improvements:**

* Improved line wrapping logic to handle Unicode characters correctly when splitting log lines for terminal display.